### PR TITLE
Add link to spatial capture-recapture repo

### DIFF
--- a/resources_and_books.md
+++ b/resources_and_books.md
@@ -1,6 +1,6 @@
-## Books 
+## Books
 
-Stan translation by Hiroki Itô of [_Bayesian Population Analysis using WinBUGS_](https://github.com/stan-dev/example-models/tree/master/BPA) 
+Stan translation by Hiroki Itô of [_Bayesian Population Analysis using WinBUGS_](https://github.com/stan-dev/example-models/tree/master/BPA)
 
 [Bayesian Data Analysis in Ecology Using Linear Models with R, BUGS, and Stan](https://www.sciencedirect.com/book/9780128013700/bayesian-data-analysis-in-ecology-using-linear-models-with-r-bugs-and-stan)
 
@@ -20,10 +20,11 @@ https://nwfsc-timeseries.github.io/atsar/)
 - [Case study: hierarchical model for cherry flowering (In French)](https://stateofther.github.io/post/rstan/WorkingWithStan_part2.html)
 - [A step-by-step guide to marginalizing over discrete parameters for ecologists using Stan](https://mbjoseph.github.io/posts/2020-04-28-a-step-by-step-guide-to-marginalizing-over-discrete-parameters-for-ecologists-using-stan/)
 - hidden Markov models for animal movement: [Discussion and code comparing moveHMM and Stan](https://groups.google.com/forum/#!searchin/stan-users/animal$20movement%7Csort:date/stan-users/72BEgxLIZjo/95037NfXAgAJ) and [another here](https://arxiv.org/abs/1806.10639)  
-- hidden Markov model R package [BayesHMM](https://luisdamiano.github.io/BayesHMM/articles/introduction.html#introduction) 
+- hidden Markov model R package [BayesHMM](https://luisdamiano.github.io/BayesHMM/articles/introduction.html#introduction)
 - [Predator-Prey Population Dynamics: the Lotka-Volterra model in Stan](https://mc-stan.org/users/documentation/case-studies/lotka-volterra-predator-prey.html)
 - [Multiple Species-Site Occupancy Model](https://mc-stan.org/users/documentation/case-studies/dorazio-royle-occupancy.html)
 - [Fitting the Cormack-Jolly-Seber (CJS) model](https://mc-stan.org/docs/2_22/stan-users-guide/latent-discrete-chapter.html)
 - [Fitting a Generalized Bayesian Factor Model with Stan](https://rive-numeri-lab.github.io/2018/09/04/GBFM.html)
 - [Dirichlet regression and the 2018 Quebec Elections (with brms)](https://rive-numeri-lab.github.io/2019/10/30/DirichletElections.html)
 - [_Series of blog posts on_: Selecting covariates in multiple regression](http://darwin.eeb.uconn.edu/uncommon-ground/variable-selection-in-multiple-regression/)
+- [Spatial capture-recapture models in Stan](https://github.com/mbjoseph/scr-stan)


### PR DESCRIPTION
This PR adds a link to the [scr-stan](https://github.com/mbjoseph/scr-stan) spatial capture-recapture GitHub repo in the resources and books page! 